### PR TITLE
Close writable stream

### DIFF
--- a/Scripts/format.js
+++ b/Scripts/format.js
@@ -13,19 +13,21 @@ exports.run = (unformattedContent) => {
     const writer = stdin.getWriter();
 
     writer.ready.then(() => {
-      return writer.write(unformattedContent);
-    }).then(writer.close());
+      writer.write(unformattedContent);
+    }).then(() => {
+      writer.close();
+    });
 
-    process.onStdout(function(line) {
+    process.onStdout(function (line) {
       formattedContent += line;
     });
 
-    process.onStderr(function(line) {
+    process.onStderr(function (line) {
       error += line;
       console.log("Error with mix format: " + line);
     });
 
-    process.onDidExit(function(code) {
+    process.onDidExit(function (code) {
       if (code !== 0) {
         reject(error);
         return;

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -1,3 +1,10 @@
 const willSave = require('willSave.js');
 
-nova.workspace.onDidAddTextEditor((textEditor) => {willSave.listen(textEditor);});
+nova.workspace.onDidAddTextEditor(textEditor => {
+    if (textEditor.document.syntax != "elixir") {
+        console.warn("Exiting early; document syntax not Elixir.");
+        return;
+    }
+
+    willSave.listen(textEditor);
+});


### PR DESCRIPTION
This extension wasn't working out of the box for me. After a bit of trial and error, I found that by invoking `writer.close()` within an anonymous function ensures that the file contents are pushed to `stdin`. 